### PR TITLE
Fix memory leak issue in HTTPClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.4.7] - 2025-03-27
+### Added
+- add forced cache refresh after removing and saving Bambu credentials
+- add functionality to remove Bambu credentials and update API handling
+- add rfid_bambu.html and update bambu connection handling
+
+### Changed
+- update platformio.ini for version v1.4.7
+- Merge branch 'testing'
+- update remove button for Bambu credentials with red background
+- Merge pull request #28 from tugsi/main
+
+### Fixed
+- handle Bambu connection state by introducing bambuDisabled flag
+- Fix rfid.js-Failure with X1-Series, if you wanna send a Spool to AMS:  - Uncaught TypeError: Cannot read properties of undefined (reading 'replace')     at handleSpoolIn (rfid.js:493:67)     at HTMLButtonElement.onclick ((Index):1:1) handleSpoolIn	@	rfid.js:493 onclick	@	(Index):1
+
+
 ## [1.4.6] - 2025-03-26
 ### Changed
 - update platformio.ini for version v1.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.6] - 2025-03-26
+### Changed
+- update platformio.ini for version v1.4.6
+
+### Fixed
+- handle potential undefined value for tray_info_idx in handleSpoolIn function, by @tugsi
+
+
 ## [1.4.5] - 2025-03-25
 ### Changed
 - update platformio.ini for version v1.4.5

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [common]
-version = "1.4.6"
+version = "1.4.7"
 to_old_version = "1.4.0"
 
 ##

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [common]
-version = "1.4.5"
+version = "1.4.6"
 to_old_version = "1.4.0"
 
 ##

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -94,6 +94,7 @@ void sendToApi(void *parameter) {
     String octoToken = params->octoToken;    
 
     HTTPClient http;
+    http.setReuse(false);
     http.begin(spoolsUrl);
     http.addHeader("Content-Type", "application/json");
     if (octoEnabled && octoToken != "") http.addHeader("X-Api-Key", octoToken);


### PR DESCRIPTION
The HTTPClient tries to reuse the open TCP connection not freeing up the memory after the reques thas been sent. This causes the spoolman updates to fail after a few times.