### PR TITLE
Fixes some issues with the new location tags

### DIFF
--- a/html/rfid.js
+++ b/html/rfid.js
@@ -555,7 +555,10 @@ function updateNfcData(data) {
     }
 
     // HTML für die Datenanzeige erstellen
-    let html = `
+    let html = "";
+
+    if(data.sm_id){
+        html = `
         <div class="nfc-card-data" style="margin-top: 10px;">
             <p><strong>Brand:</strong> ${data.brand || 'N/A'}</p>
             <p><strong>Type:</strong> ${data.type || 'N/A'} ${data.color_hex ? `<span style="
@@ -568,10 +571,27 @@ function updateNfcData(data) {
                 border-radius: 3px;
                 margin-left: 5px;
             "></span>` : ''}</p>
-    `;
+        `;
 
-    // Spoolman ID anzeigen
-    html += `<p><strong>Spoolman ID:</strong> ${data.sm_id || 'No Spoolman ID'}</p>`;
+        // Spoolman ID anzeigen
+        html += `<p><strong>Spoolman ID:</strong> ${data.sm_id || 'No Spoolman ID'}</p>`;
+     }
+     else if(data.location)
+     {
+        html = `
+        <div class="nfc-card-data" style="margin-top: 10px;">
+            <p><strong>Location:</strong> ${data.location || 'N/A'}</p>
+        `;
+     }
+     else
+     {
+        html = `
+        <div class="nfc-card-data" style="margin-top: 10px;">
+            <p><strong>Unknown tag</strong></p>
+        `;
+     }
+
+    
 
     // Nur wenn eine sm_id vorhanden ist, aktualisiere die Dropdowns
     if (data.sm_id) {
@@ -626,11 +646,11 @@ function writeNfcTag() {
 
     // Erstelle das NFC-Datenpaket mit korrekten Datentypen
     const nfcData = {
-        //color_hex: selectedSpool.filament.color_hex || "FFFFFF",
-        //type: selectedSpool.filament.material,
-        //min_temp: minTemp,
-        //max_temp: maxTemp,
-        //brand: selectedSpool.filament.vendor.name,
+        color_hex: selectedSpool.filament.color_hex || "FFFFFF",
+        type: selectedSpool.filament.material,
+        min_temp: minTemp,
+        max_temp: maxTemp,
+        brand: selectedSpool.filament.vendor.name,
         sm_id: String(selectedSpool.id) // Konvertiere zu String
     };
 

--- a/html/rfid_bambu.html
+++ b/html/rfid_bambu.html
@@ -139,6 +139,18 @@
                 <p id="nfcInfo" class="nfc-status"></p>
                 <button id="writeNfcButton" class="btn btn-primary hidden" onclick="writeNfcTag()">Write Tag</button>
             </div>
+
+            <div class="feature-box">
+                <h2>Spoolman Locations</h2>
+                <label for="locationSelect">Location:</label>
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                    <select id="locationSelect" class="styled-select">
+                        <option value="">Please choose...</option>
+                    </select>
+                </div>
+                <p id="nfcInfoLocation" class="nfc-status"></p>
+                <button id="writeLocationNfcButton" class="btn btn-primary hidden" onclick="writeLocationNfcTag()">Write Location Tag</button>
+            </div>
         </div>
 
         <!-- Rechte Spalte -->


### PR DESCRIPTION
Fixes an issue where the location dropdown is not visible if the Bambu integration is active. Adds support for the "NFC-Tag" view on the webpage, it now also shows info about the location tags. Revers a change that was not supposed to go into main where the amount of data written to the spool tag is reduced to only the sm_id.