### PR TITLE
docs: Update Spoolman CORS configuration in README

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -170,15 +170,26 @@ A+ grün*
   - Verbindungskabel
 
 ## Wichtiger Hinweis
-Du musst Spoolman auf DEBUG Modus setzten, da man bisher in Spoolman keine CORS Domains setzen kann!
+Für die CORS-Kompatibilität mit FilaMan musst du Spoolman so konfigurieren, dass Cross-Origin-Requests erlaubt werden.
 
+### Docker Installation
+Füge diese Umgebungsvariable zu deiner Spoolman Docker-Konfiguration hinzu:
+
+**In deiner `docker-compose.yml`:**
+```yaml
+services:
+  spoolman:
+    # ... andere Konfiguration
+    environment:
+      - SPOOLMAN_CORS_ORIGIN=*
 ```
-# Enable debug mode
-# If enabled, the client will accept requests from any host
-# This can be useful when developing, but is also a security risk
-# Default: FALSE
-#SPOOLMAN_DEBUG_MODE=TRUE
+
+**Oder bei Verwendung von `docker run`:**
+```bash
+docker run -e SPOOLMAN_CORS_ORIGIN=* [andere Optionen] ghcr.io/donkie/spoolman:latest
 ```
+
+**Sicherheitshinweis:** Die Verwendung von `SPOOLMAN_CORS_ORIGIN=*` erlaubt Requests von jeder Origin. Für Produktionsumgebungen solltest du stattdessen die spezifische IP-Adresse deines FilaMan-Systems angeben (z.B. `SPOOLMAN_CORS_ORIGIN=http://192.168.1.100`) anstelle von `*`, um die Sicherheit zu erhöhen.
 
 ## Schritt-für-Schritt Installation
 ### Einfache Installation

--- a/README.md
+++ b/README.md
@@ -173,15 +173,26 @@ A+ green*
   - Connecting wires
 
 ## Important Note
-You have to activate Spoolman in debug mode, because you are not able to set CORS Domains in Spoolman yet.
+For CORS compatibility with FilaMan, you need to configure Spoolman to allow cross-origin requests.
 
+### Docker Installation
+Add this environment variable to your Spoolman Docker configuration:
+
+**In your `docker-compose.yml`:**
+```yaml
+services:
+  spoolman:
+    # ... other configuration
+    environment:
+      - SPOOLMAN_CORS_ORIGIN=*
 ```
-# Enable debug mode
-# If enabled, the client will accept requests from any host
-# This can be useful when developing, but is also a security risk
-# Default: FALSE
-#SPOOLMAN_DEBUG_MODE=TRUE
+
+**Or when using `docker run`:**
+```bash
+docker run -e SPOOLMAN_CORS_ORIGIN=* [other options] ghcr.io/donkie/spoolman:latest
 ```
+
+**Security Note:** Using `SPOOLMAN_CORS_ORIGIN=*` allows requests from any origin. For production environments, consider specifying your FilaMan's specific IP address (e.g., `SPOOLMAN_CORS_ORIGIN=http://192.168.1.100`) instead of `*` for better security.
 
 
 ## Step-by-Step Installation


### PR DESCRIPTION
docs: Update Spoolman CORS configuration in README

- Remove outdated DEBUG_MODE recommendation
- Add SPOOLMAN_CORS_ORIGIN environment variable usage
- Include practical Docker installation examples
- Add security note about using wildcard vs specific origins
- Clarify both docker-compose.yml and docker run methods

This update reflects the new CORS configuration added in PR #605,
making it easier for users to set up FilaMan with Spoolman without
enabling debug mode.