### PR TITLE
improve: Increase scale calibration timing to 10s for weight setup/removal

### DIFF
--- a/src/scale.cpp
+++ b/src/scale.cpp
@@ -309,7 +309,7 @@ uint8_t calibrate_scale() {
 
     oledShowProgressBar(1, 3, "Scale Cal.", "Place the weight");
 
-    for (uint16_t i = 0; i < 5000; i++) {
+    for (uint16_t i = 0; i < 10000; i++) {
       yield();
       vTaskDelay(pdMS_TO_TICKS(1));
       esp_task_wdt_reset();
@@ -344,7 +344,7 @@ uint8_t calibrate_scale() {
 
       scale.set_scale(newCalibrationValue);
       resetWeightFilter(); // Reset filter after calibration
-      for (uint16_t i = 0; i < 2000; i++) {
+      for (uint16_t i = 0; i < 10000; i++) {
         yield();
         vTaskDelay(pdMS_TO_TICKS(1));
         esp_task_wdt_reset();


### PR DESCRIPTION
Increase Scale Calibration Timing for Multi-Weight Setup
Problem
When calibrating the scale with multiple small calibration weights (instead of a single 500g weight), the current 5-second window for placing the weights is insufficient. Users need more time to carefully stack individual weights on the scale without rushing or making mistakes.

Solution
Extended the calibration timing phases:

"Place the weight" phase: 5s → 10s (allows time to arrange multiple small weights)
"Remove weight" phase: 2s → 10s (gives users enough time to carefully remove all weights)

Changes:
Modified src/scale.cpp - Lines 312 & 347: Increased loop iterations from 5000/2000 to 10000

Benefits:
More flexible calibration for users with alternative weight options
Reduces risk of calibration errors due to time pressure
Better user experience for different scale calibration scenarios

Testing:
Verified timing: 10,000 iterations × 1ms = 10 seconds per phase
No changes to core calibration logic or display messages
Backward compatible - longer timeout doesn't break existing workflows
