### PR TITLE
Support WSS when using Filaman over HTTPS

### DIFF
--- a/html/rfid.js
+++ b/html/rfid.js
@@ -59,7 +59,8 @@ function initWebSocket() {
     }
 
     try {
-        socket = new WebSocket('ws://' + window.location.host + '/ws');
+        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        socket = new WebSocket(protocol + '//' + window.location.host + '/ws');
         
         socket.onopen = function() {
             isConnected = true;

--- a/html/upgrade.html
+++ b/html/upgrade.html
@@ -102,7 +102,8 @@
         let wsReconnectTimer = null;
 
         function connectWebSocket() {
-            ws = new WebSocket('ws://' + window.location.host + '/ws');
+            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            ws = new WebSocket(protocol + '//' + window.location.host + '/ws');
             
             ws.onmessage = function(event) {
                 try {

--- a/html/waage.html
+++ b/html/waage.html
@@ -86,7 +86,8 @@
         const statusMessage = document.getElementById('statusMessage');
 
         function connectWebSocket() {
-            ws = new WebSocket(`ws://${window.location.hostname}/ws`);
+            const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+            ws = new WebSocket(`${protocol}//${window.location.host}/ws`);
             
             ws.onopen = () => {
                 console.log('WebSocket verbunden');


### PR DESCRIPTION
I put Filaman behind a reverse proxy over HTTPS and got an error that I can't mix `https` with `ws`. Filaman will now use `wss` when it detects that the page is being served over `https`.